### PR TITLE
Make project title "Coding standards front end"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Standards and conventions
+# Coding Standards Front End
 A collection of web project and interface development standards and conventions

--- a/index.html
+++ b/index.html
@@ -5,13 +5,13 @@
 		<meta charset="UTF-8" />
 		<meta name="description" content="A collection of web project and interface development standards and conventions" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Coding standards and development guidelines</title>
+		<title>Coding standards front end</title>
 		<link href="assets/styles/project.css" rel="stylesheet" />
 		<script src="assets/vendor/libs/modernizr.js"></script>
 	</head>
 	<body>
 		<header class="banner" role="banner">
-			<h1>Interface development standards</h1>
+			<h1>Coding standards front end</h1>
 		</header>
 
 		<nav class="navigation" role="navigation">


### PR DESCRIPTION
This is really niggly. Sorry :)

There are 4 different names used in the project:
- Coding Standards Front End ([repo name](https://github.com/specialmoves/coding-standards-front-end))
- Standards and conventions ([README](https://github.com/specialmoves/coding-standards-front-end/blob/master/README.md))
- Coding standards and development guidelines ([title tag](https://github.com/specialmoves/coding-standards-front-end/blob/master/index.html#L8))
- Interface development standards ([page title](https://github.com/specialmoves/coding-standards-front-end/blob/master/index.html#L14))

Would it be worth picking a single name and settling on it?

If so, my suggestion would be to go with the repo name; smallest impact and is still nice and descriptive.
